### PR TITLE
Fix invalid strict-mode syntax with best guesses

### DIFF
--- a/sources/values.js
+++ b/sources/values.js
@@ -9,7 +9,21 @@ function ValueStream (values) {
 }
 
 ValueStream.prototype.resume = function () {
-  while(!this.sink.paused && !(this.ended || this.ended = this._i >= this._values.length))
+  const shouldWrite = () => {
+    if (this.sink.paused) {
+      return false
+    }
+
+    if (this.ended) {
+      return false
+    } else {
+      const pastEnd = this._i >= this._values.length
+      this.ended = pastEnd
+      return !!pastEnd
+    }
+  }
+
+  while(shouldWrite())
     this.sink.write(this._values[this._i++])
 
   if(this.ended && !this.sink.ended)

--- a/throughs/flatten.js
+++ b/throughs/flatten.js
@@ -32,10 +32,8 @@ FlattenStream.prototype.resume = function (data) {
   else {
     while(!this.sink.paused && this.queue.length)
       this.sink.write(this.queue.shift())
-    if(!this.queue.length) {
-      else {
+    if(this.queue.length) {
         this.resume()
-      }
     } else
       //stay paused if we didn't write everything
       this.paused = true


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: ssbc/ssb-server#683

---

Actually, is this module being actively maintained? We're using it in ssb-server (`ssb-ebt > epidemic-broadcast-trees` and `ssb-ebt > push-stream-to-pull-stream`) but IIRC pull-streams are superior?