### PR TITLE
Fix heap benchmark, add .gitignore, update Travis CI settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
-  - 0.8
   - node
   - lts/*
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+  - node
+  - lts/*
 matrix:
   - env: NPM_SCRIPT="test"
   - env: NPM_SCRIPT="benchmark:heap"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,9 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
+matrix:
+  - env: NPM_SCRIPT="test"
+  - env: NPM_SCRIPT="benchmark:heap"
+  - env: NPM_SCRIPT="benchmark:push"
+script:
+  - npm run $NPM_SCRIPT

--- a/benchmarks/heap.js
+++ b/benchmarks/heap.js
@@ -10,8 +10,8 @@ function heap (name, Stream) {
   a = null
 }
 
-heap('Values', require('../values'))
-heap('Map', require('../async'))
-heap('Collect', require('../collect'))
+heap('Values', require('../sources/values'))
+heap('Map', require('../throughs/async'))
+heap('Collect', require('../sinks/collect'))
 
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "tape": "^4.8.0"
   },
   "scripts": {
+    "benchmark:heap": "node ./benchmarks/heap.js",
+    "benchmark:push": "node ./benchmarks/push.js",
     "test": "set -e; for t in test/*.js; do node $t; done"
   },
   "author": "'Dominic Tarr' <dominic.tarr@gmail.com> (dominictarr.com)",


### PR DESCRIPTION
This PR does the following:
- Fixes file paths for `./benchmarks/heap.js`, which were broken
- Adds benchmark scripts to `package.json`
- Adds `.gitignore`
- Updates TravisCI configuration to support a reasonable (and far more recent) range of NodeJS builds
  - `npm install` doesn't even work for the older NodeJS versions